### PR TITLE
Animate only when the scroll position changes

### DIFF
--- a/parallax/js/picasso.js
+++ b/parallax/js/picasso.js
@@ -13,6 +13,7 @@
         windowHeight =             0,
         windowWidth =              0,
         prevKeyframesDurations =   0,
+        prevScrollTop =            0,
         scrollTop =                0,
         relativeScrollTop =        0,
         currentKeyframe =          0,
@@ -357,9 +358,10 @@
     updatePage = function() {
       window.requestAnimationFrame(function() {
         setScrollTops();
-        if(scrollTop > 0 && scrollTop <= (bodyHeight - windowHeight)) {
+        if(prevScrollTop != scrollTop) {
           animateElements();
           setKeyframe();
+          prevScrollTop = scrollTop;
         }
       });
     }


### PR DESCRIPTION
The previous test had a few issues:
1. Didn't call animateElements when reaching the top of the page
2. Didn't account for float windowHeight and bodyHeight and thus occasionally didn't call animateElements when reaching the bottom of the page
3. Called animateElements even if the scroll position didn't change
